### PR TITLE
Added "-c gpuctx" option for GPU context. Now you must use "-c x11" i…

### DIFF
--- a/README
+++ b/README
@@ -57,6 +57,17 @@ Command line arguments
   The hwdec which are used by mpv, this is directly passed as hwdec
   to mpv. For latest mpv use -h gpu (also see -g parameter)
 
+-c gpuctx
+  mpv --gpu-context (Default: auto)
+  The GPU context (auto, x11, drm, x11egl).
+
+  It is best to set "-v gpu -h auto".
+  Set "-v gpu -h cuda -c x11" for use cuda with X11 and GLX. Latest mpv set X11 GLX deprecated, you need configure mpv with --enable-gl-x11.
+  Set "-v gpu -h auto -c drm" for use drm output and hardware decoder without X11.
+  Set "-v vdpau -h vdpau -c x11" for use vpdau with X11 and GLX.
+  Set "-v vaapi -h vaapi -c x11" for use vaapi with X11 and GLX, GLX is slower in Intel than EGL.
+  Set "-v gpu -h vaapi-copy" for use vaapi with X11 and EGL.
+
 -d device
   optical disc device (Default: /dev/dvd)
   The device which is used for playback of optical media
@@ -90,11 +101,7 @@ Command line arguments
 -w
    windowed mode, not fullscreen
 
--g
 -g geometry
-  normally mpv use EGL for hwdec=gpu and can not works with X11, if this parameter is set
-  mpv use GLX for hwdec=gpu and can works with X11.
-  Latest mpv set X11 GLX deprecated, you need configure mpv with --enable-gl-x11.
   You can set X11 geometry with this parameter [W[xH]][+-x+-y][/WS] or x:y.
   But size of OSD get from softhddevice geometry!!!
 
@@ -195,4 +202,3 @@ SVDRP commands
 --------------
 
 PLAY filename           play given filename
-

--- a/config.c
+++ b/config.c
@@ -32,7 +32,7 @@ cMpvPluginConfig::cMpvPluginConfig()
   RefreshRate = 0;
   VideoOut = "vdpau";
   HwDec = "vdpau";
-  UseGlx = 0;
+  GpuCtx = "auto";
   AudioOut = "alsa:device=default";
   DiscDevice = "/dev/dvd";
   Languages = "deu,de,ger,eng,en";
@@ -72,7 +72,7 @@ int cMpvPluginConfig::ProcessArgs(int argc, char *const argv[])
 
   for (;;)
   {
-    switch (getopt(argc, argv, "a:v:h:d:b:l:x:rm:swg:"))
+    switch (getopt(argc, argv, "a:v:h:c:d:b:l:x:rm:swg:"))
     {
       case 'a': // audio out
         AudioOut = optarg;
@@ -82,6 +82,9 @@ int cMpvPluginConfig::ProcessArgs(int argc, char *const argv[])
       continue;
       case 'h': // hwdec-codecs
         HwDec = optarg;
+      continue;
+      case 'c': // gpu-context
+        GpuCtx = optarg;
       continue;
       case 'd': // dvd-device
         DiscDevice = optarg;
@@ -107,9 +110,8 @@ int cMpvPluginConfig::ProcessArgs(int argc, char *const argv[])
       case 'w':
         Windowed = 1;
       continue;
-      case 'g': // glx with x11 and geometry
+      case 'g':
         Geometry = optarg;
-        UseGlx = 1;
       continue;
       case EOF:
       break;
@@ -117,11 +119,6 @@ int cMpvPluginConfig::ProcessArgs(int argc, char *const argv[])
         esyslog("[mpv]: missing argument for option '%c'\n", optopt);
         return 0;
       default:
-        if (optopt == 'g') //glx with x11
-        {
-          UseGlx = 1;
-          continue;
-        }
         esyslog("[mpv]: unknown option '%c'\n", optopt);
         return 0;
     }
@@ -144,6 +141,7 @@ const char *cMpvPluginConfig::CommandLineHelp(void)
     "  -a audio\tmpv --ao (Default: alsa:device=default)\n"
     "  -v video\tmpv --vo (Default: vdpau)\n"
     "  -h hwdec\tmpv --hwdec-codecs (Default: vdpau)\n"
+    "  -c gpuctx\tmpv --gpu-context (Default: auto)\n"
     "  -d device\tmpv optical disc device (Default: /dev/dvd)\n"
     "  -l languages\tlanguages for audio and subtitles (Default: deu,de,ger,eng,en)\n"
     "  -b /dir\tbrowser root directory\n"
@@ -154,7 +152,6 @@ const char *cMpvPluginConfig::CommandLineHelp(void)
 #endif
     "  -m text\ttext displayed in VDR main menu (Default: MPV)\n"
     "  -s\t\tdon't load mpv LUA scripts\n"
-    "  -g\t\tuse GLX with X11\n"
     "  -g geometry\t X11 geometry [W[xH]][+-x+-y][/WS] or x:y\n"
     ;
 }

--- a/config.h
+++ b/config.h
@@ -48,7 +48,7 @@ class cMpvPluginConfig
     int RefreshRate;                // enable modeline switching
     string VideoOut;                // video out device
     string HwDec;                   // hwdec codecs
-    int UseGlx;                     // enable use GLX with X11, because mpv use EGL by default.
+    string GpuCtx;                  // gpu context
     string AudioOut;                // audio out device
     string DiscDevice;              // optical disc device
     string Languages;               // language string for audio and subtitle TODO move to Setup menu

--- a/mpv.c
+++ b/mpv.c
@@ -19,7 +19,7 @@
 #include "menu_options.h"
 #include "mpv_service.h"
 
-static const char *VERSION = "1.0.1"
+static const char *VERSION = "1.1.0"
 #ifdef GIT_REV
     "-GIT" GIT_REV
 #endif

--- a/player.c
+++ b/player.c
@@ -397,10 +397,7 @@ void cMpvPlayer::PlayerStart()
 
   check_error(mpv_set_option_string(hMpv, "vo", MpvPluginConfig->VideoOut.c_str()));
   check_error(mpv_set_option_string(hMpv, "hwdec", MpvPluginConfig->HwDec.c_str()));
-  if (MpvPluginConfig->UseGlx)
-  {
-    check_error(mpv_set_option_string(hMpv, "gpu-context", "x11"));
-  }
+  check_error(mpv_set_option_string(hMpv, "gpu-context", MpvPluginConfig->GpuCtx.c_str()));
   if (strcmp(MpvPluginConfig->Geometry.c_str(),""))
   {
     check_error(mpv_set_option_string(hMpv, "geometry", MpvPluginConfig->Geometry.c_str()));


### PR DESCRIPTION
…nstead "-g" for X11 GLX (look at readme). Version 1.1.0.