### PR TITLE
Added drm device selection. /dev/dri/card1 and /dev/dri/card0 will be…

### DIFF
--- a/README
+++ b/README
@@ -105,6 +105,9 @@ Command line arguments
   You can set X11 geometry with this parameter [W[xH]][+-x+-y][/WS] or x:y.
   Resolution of OSD get from settings of output plugin (softhd*). OSD is scaled to video size.
 
+-e drm device
+  force set drm device (ex. /dev/dri/card0). Otherwise they will be tried /dev/dri/card1 and /dev/dri/card0.
+
 Plugin setup options
 --------------------
 

--- a/config.c
+++ b/config.c
@@ -45,6 +45,7 @@ cMpvPluginConfig::cMpvPluginConfig()
   Geometry = "";
   Windowed = 0;
   ShowOptions = 0;
+  DRMdev = "";
 }
 
 vector<string> cMpvPluginConfig::ExplodeString(string Input)
@@ -73,7 +74,7 @@ int cMpvPluginConfig::ProcessArgs(int argc, char *const argv[])
 
   for (;;)
   {
-    switch (getopt(argc, argv, "a:v:h:c:d:b:l:x:rm:swg:"))
+    switch (getopt(argc, argv, "a:v:h:c:d:b:l:x:rm:swg:e:"))
     {
       case 'a': // audio out
         AudioOut = optarg;
@@ -113,6 +114,9 @@ int cMpvPluginConfig::ProcessArgs(int argc, char *const argv[])
       continue;
       case 'g':
         Geometry = optarg;
+      continue;
+      case 'e':
+        DRMdev = optarg;
       continue;
       case EOF:
       break;

--- a/config.h
+++ b/config.h
@@ -60,6 +60,7 @@ class cMpvPluginConfig
     string X11Display;              // X11 display used for mpv
     string TitleOverride;           // title to display (ovveride used via service interface)
     string Geometry;                // X11 display geometry
+    string DRMdev;                  // DRM device
     int Windowed;                   // windowed mode, not fullscreen
 
     int ShowOptions;                // switch show menu options or filebrowser menu

--- a/mpv.c
+++ b/mpv.c
@@ -19,7 +19,7 @@
 #include "menu_options.h"
 #include "mpv_service.h"
 
-static const char *VERSION = "1.6.1"
+static const char *VERSION = "1.7.0"
 #ifdef GIT_REV
     "-GIT" GIT_REV
 #endif

--- a/player.h
+++ b/player.h
@@ -26,6 +26,7 @@ class cMpvPlayer:public cPlayer
     void SwitchOsdToMpv();
     void PlayerHideCursor();
     void PlayerGetDRM();
+    int PlayerTryDRM();
 
     string PlayFilename;              // file to play
     bool PlayShuffle;                 // shuffle playlist


### PR DESCRIPTION
… tried. You can set the drm device force with -e option (-e /dev/dri/card0). Version 1.7.0.